### PR TITLE
feat: add variable to configure auto-sync of the Argo CD Application

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,19 +37,19 @@ The following input variables are required:
 
 ==== [[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
 
-Description: n/a
+Description: Namespace used by Argo CD where the Application and AppProject resources should be created.
 
 Type: `string`
 
 ==== [[input_base_domain]] <<input_base_domain,base_domain>>
 
-Description: n/a
+Description: Base domain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
 ==== [[input_cluster_name]] <<input_cluster_name,cluster_name>>
 
-Description: n/a
+Description: Name given to the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -57,9 +57,33 @@ Type: `string`
 
 The following input variables are optional (have default values):
 
+==== [[input_app_autosync]] <<input_app_autosync,app_autosync>>
+
+Description: Automated sync options for the Argo CD Application resource.
+
+Type:
+[source,hcl]
+----
+object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "allow_empty": false,
+  "prune": true,
+  "self_heal": true
+}
+----
+
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
-Description: n/a
+Description: SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 
 Type: `string`
 
@@ -67,7 +91,7 @@ Default: `"ca-issuer"`
 
 ==== [[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
 
-Description: n/a
+Description: IDs of the other modules on which this module depends on.
 
 Type: `map(string)`
 
@@ -75,7 +99,7 @@ Default: `{}`
 
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
-Description: Grafana settings
+Description: Most frequently used Grafana settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
 
 Type: `any`
 
@@ -83,7 +107,7 @@ Default: `{}`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
-Description: Helm values, passed as a list of HCL structures.
+Description: Helm chart value overrides. They should be passed as a list of HCL structures.
 
 Type: `any`
 
@@ -91,7 +115,7 @@ Default: `[]`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
-Description: n/a
+Description: Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 
 Type: `string`
 
@@ -113,13 +137,9 @@ The following outputs are exported:
 
 Description: The admin password for Grafana.
 
-==== [[output_grafana_enabled]] <<output_grafana_enabled,grafana_enabled>>
-
-Description: n/a
-
 ==== [[output_id]] <<output_id,id>>
 
-Description: n/a
+Description: ID to pass other modules in order to refer to this module as a dependency.
 // END_TF_DOCS
 // BEGIN_TF_TABLES
 
@@ -154,50 +174,76 @@ Description: n/a
 [cols="a,a,a,a,a",options="header,autowidth"]
 |===
 |Name |Description |Type |Default |Required
+|[[input_app_autosync]] <<input_app_autosync,app_autosync>>
+|Automated sync options for the Argo CD Application resource.
+|
+
+[source]
+----
+object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+----
+
+|
+
+[source]
+----
+{
+  "allow_empty": false,
+  "prune": true,
+  "self_heal": true
+}
+----
+
+|no
+
 |[[input_argocd_namespace]] <<input_argocd_namespace,argocd_namespace>>
-|n/a
+|Namespace used by Argo CD where the Application and AppProject resources should be created.
 |`string`
 |n/a
 |yes
 
 |[[input_base_domain]] <<input_base_domain,base_domain>>
-|n/a
+|Base domain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |n/a
 |yes
 
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
-|n/a
+|SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
 |`"ca-issuer"`
 |no
 
 |[[input_cluster_name]] <<input_cluster_name,cluster_name>>
-|n/a
+|Name given to the cluster. Value used for the ingress' URL of the application.
 |`string`
 |n/a
 |yes
 
 |[[input_dependency_ids]] <<input_dependency_ids,dependency_ids>>
-|n/a
+|IDs of the other modules on which this module depends on.
 |`map(string)`
 |`{}`
 |no
 
 |[[input_grafana]] <<input_grafana,grafana>>
-|Grafana settings
+|Most frequently used Grafana settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
 |`any`
 |`{}`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
-|Helm values, passed as a list of HCL structures.
+|Helm chart value overrides. They should be passed as a list of HCL structures.
 |`any`
 |`[]`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
-|n/a
+|Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist.
 |`string`
 |`"grafana"`
 |no
@@ -216,7 +262,6 @@ Description: n/a
 |===
 |Name |Description
 |[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
-|[[output_grafana_enabled]] <<output_grafana_enabled,grafana_enabled>> |n/a
-|[[output_id]] <<output_id,id>> |n/a
+|[[output_id]] <<output_id,id>> |ID to pass other modules in order to refer to this module as a dependency.
 |===
 // END_TF_TABLES

--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ Default: `{}`
 
 ==== [[input_grafana]] <<input_grafana,grafana>>
 
-Description: Most frequently used Grafana settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
+Description: Most frequently used Grafana settings. This variable is merged with the local value `grafana_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
 
 Type: `any`
 
@@ -231,7 +231,7 @@ object({
 |no
 
 |[[input_grafana]] <<input_grafana,grafana>>
-|Most frequently used Grafana settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
+|Most frequently used Grafana settings. This variable is merged with the local value `grafana_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`.
 |`any`
 |`{}`
 |no

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "argocd_application" "this" {
     delete = "15m"
   }
 
-  wait = true
+  wait = var.app_autosync == { "allow_empty" = null, "prune" = null, "self_heal" = null } ? false : true
 
   spec {
     project = argocd_project.this.metadata.0.name
@@ -71,11 +71,7 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated = {
-        allow_empty = false
-        prune       = true
-        self_heal   = true
-      }
+      automated = var.app_autosync
 
       retry {
         backoff = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,6 @@
 output "id" {
-  value = resource.null_resource.this.id
+  description = "ID to pass other modules in order to refer to this module as a dependency."
+  value       = resource.null_resource.this.id
 }
 
 output "grafana_admin_password" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,3 @@ output "grafana_admin_password" {
   value       = local.grafana.admin_password
   sensitive   = true
 }
-
-output "grafana_enabled" {
-  value = local.grafana.enabled
-}

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "dependency_ids" {
 #######################
 
 variable "grafana" {
-  description = "Most frequently used Grafana settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`."
+  description = "Most frequently used Grafana settings. This variable is merged with the local value `grafana_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`."
   type        = any
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,17 +4,17 @@
 
 variable "cluster_name" {
   description = "Name given to the cluster. Value used for the ingress' URL of the application."
-  type = string
+  type        = string
 }
 
 variable "base_domain" {
   description = "Base domain of the cluster. Value used for the ingress' URL of the application."
-  type = string
+  type        = string
 }
 
 variable "argocd_namespace" {
   description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
-  type = string
+  type        = string
 }
 
 variable "target_revision" {
@@ -25,14 +25,14 @@ variable "target_revision" {
 
 variable "cluster_issuer" {
   description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files."
-  type    = string
-  default = "ca-issuer"
+  type        = string
+  default     = "ca-issuer"
 }
 
 variable "namespace" {
   description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
-  type    = string
-  default = "grafana"
+  type        = string
+  default     = "grafana"
 }
 
 variable "helm_values" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,14 +3,17 @@
 #######################
 
 variable "cluster_name" {
+  description = "Name given to the cluster. Value used for the ingress' URL of the application."
   type = string
 }
 
 variable "base_domain" {
+  description = "Base domain of the cluster. Value used for the ingress' URL of the application."
   type = string
 }
 
 variable "argocd_namespace" {
+  description = "Namespace used by Argo CD where the Application and AppProject resources should be created."
   type = string
 }
 
@@ -21,17 +24,19 @@ variable "target_revision" {
 }
 
 variable "cluster_issuer" {
+  description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files."
   type    = string
   default = "ca-issuer"
 }
 
 variable "namespace" {
+  description = "Namespace where the applications's Kubernetes resources should be created. Namespace will be created in case it doesn't exist."
   type    = string
   default = "grafana"
 }
 
 variable "helm_values" {
-  description = "Helm values, passed as a list of HCL structures."
+  description = "Helm chart value overrides. They should be passed as a list of HCL structures."
   type        = any
   default     = []
 }
@@ -51,9 +56,9 @@ variable "app_autosync" {
 }
 
 variable "dependency_ids" {
-  type = map(string)
-
-  default = {}
+  description = "IDs of the other modules on which this module depends on."
+  type        = map(string)
+  default     = {}
 }
 
 #######################
@@ -61,7 +66,7 @@ variable "dependency_ids" {
 #######################
 
 variable "grafana" {
-  description = "Grafana settings"
+  description = "Most frequently used Grafana settings. This variable is merged with the local value `thanos_defaults`, which contains some sensible defaults. You can check the default values on the link:./local.tf[`local.tf`] file. If there still is anything other that needs to be customized, you can always pass on configuration values using the variable `helm_values`."
   type        = any
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,20 @@ variable "helm_values" {
   default     = []
 }
 
+variable "app_autosync" {
+  description = "Automated sync options for the Argo CD Application resource."
+  type = object({
+    allow_empty = optional(bool)
+    prune       = optional(bool)
+    self_heal   = optional(bool)
+  })
+  default = {
+    allow_empty = false
+    prune       = true
+    self_heal   = true
+  }
+}
+
 variable "dependency_ids" {
   type = map(string)
 


### PR DESCRIPTION
This PR adds the variable to configure auto-sync of the Argo CD Application, like in other modules.

I also took the opportunity to add some descriptions for the other outputs and variables as well as deleting an output I had forgotten to remove.